### PR TITLE
Fix Community Coding link in syllabus

### DIFF
--- a/syllabus_456_S20.Rmd
+++ b/syllabus_456_S20.Rmd
@@ -72,7 +72,7 @@ I will endeavor to have these items loaded into the gradebook in Blackboard Lear
 * 7 Individual + Group quizzes. Administered through Google Forms, lowest score dropped. 
 * Some in-class worksheets on an as-needed basis. 
 * Various active or reflective [learning activities](learning_tools.html) during/outside of class.
-* Attending [Community Coding](http://bit.ly/cc_hours.html) and/or Office Hours **4** times
+* Attending [Community Coding](http://bit.ly/cc_hours) and/or Office Hours **4** times
 * Attending an internal/external seminar talk on a topic in Applied Statistics, or a Data analysis-centric seminar talk, writing a 1 page summary about the talk, and sharing this summary in the #external-learning Slack channel.
 * Contribute to the [Applied Statistics Course Notes](https://norcalbiostat.github.io/AppliedStatistics_notes/). This could be a new example, enhancing/fixing an old example, 
     - Once you identify the piece you want to work on, PM me the section in Slack. I will send you the relevant code/data. 

--- a/syllabus_456_S20.html
+++ b/syllabus_456_S20.html
@@ -1,10 +1,11 @@
 <!DOCTYPE html>
 
-<html>
+<html xmlns="http://www.w3.org/1999/xhtml">
 
 <head>
 
 <meta charset="utf-8" />
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <meta name="generator" content="pandoc" />
 <meta http-equiv="X-UA-Compatible" content="IE=EDGE" />
 
@@ -220,7 +221,6 @@ $(document).ready(function () {
   border: none;
   display: inline-block;
   border-radius: 4px;
-  background-color: transparent;
 }
 
 .tabset-dropdown > .nav-tabs.nav-tabs-open > li {
@@ -471,7 +471,7 @@ $(document).ready(function () {
 <li>7 Individual + Group quizzes. Administered through Google Forms, lowest score dropped.</li>
 <li>Some in-class worksheets on an as-needed basis.</li>
 <li>Various active or reflective <a href="learning_tools.html">learning activities</a> during/outside of class.</li>
-<li>Attending <a href="http://bit.ly/cc_hours.html">Community Coding</a> and/or Office Hours <strong>4</strong> times</li>
+<li>Attending <a href="http://bit.ly/cc_hours">Community Coding</a> and/or Office Hours <strong>4</strong> times</li>
 <li>Attending an internal/external seminar talk on a topic in Applied Statistics, or a Data analysis-centric seminar talk, writing a 1 page summary about the talk, and sharing this summary in the #external-learning Slack channel.</li>
 <li>Contribute to the <a href="https://norcalbiostat.github.io/AppliedStatistics_notes/">Applied Statistics Course Notes</a>. This could be a new example, enhancing/fixing an old example,
 <ul>
@@ -528,7 +528,7 @@ Student Services Center 170<br />
 <p>All students are welcomed to visit the Pantry located in the Student Service Center 196, open Monday-Friday, 11am-4pm or call 530-898-4098.</p>
 <p>Please visit the Chico State Basic Needs website <a href="http://www.csuchico.edu/basic-needs" class="uri">http://www.csuchico.edu/basic-needs</a> for more information.</p>
 <hr />
-<p><em>Last updated: Tue Jan 21 2020 9:48:25 PM</em></p>
+<p><em>Last updated: Wed Jan 22 2020 6:22:06 PM</em></p>
 </div>
 </div>
 


### PR DESCRIPTION
Removing the ".html" fixes the link.

I'm not entirely sure why the other changes to the html file are there (possibly differences in my knitr) but I don't notice any adverse effects.